### PR TITLE
Add universal prefixes

### DIFF
--- a/scripty-client.el
+++ b/scripty-client.el
@@ -18,15 +18,26 @@
          (lines (if (equal "" cmd-results) '() (s-split "\n" cmd-results))))
     (-map 's-trim lines)))
 
+(defun get-args (prefix)
+  (cond
+    ((equal prefix '(4)) "")
+    ((equal prefix '(16)) scripty-last-args)
+    (t (read-string "args: " scripty-last-args))))
+
+(defun get-script (prefix)
+  (if (equal prefix '(16))
+    (list  scripty-last-script)
+    (list (ido-completing-read "command: " (scripty-get-choices) nil t scripty-last-script))))
+
 (defun scripty (arg)
   (interactive 
    (let ((choices (scripty-get-choices)))
      (if (null choices)
          '("")
-       (list (ido-completing-read "command: " (scripty-get-choices) nil t scripty-last-script)))))
+       (get-script current-prefix-arg))))
   (if (equal arg "")
       (message "No scripty dir found")
-    (let ((additional-args (read-string "args: " scripty-last-args)))
+    (let ((additional-args (get-args current-prefix-arg)))
       (setq scripty-last-script arg)
       (setq scripty-last-args additional-args)
       (async-shell-command (concat scripty-executable " " arg " " additional-args)


### PR DESCRIPTION
Use the universal prefix to suppress prompts you know you don't need.

One prefix will run the command you select with no arguments. Two prefixes will run the previous command with the previous arguments.