### PR TITLE
Order ido choices instead of providing default

### DIFF
--- a/scripty-client.el
+++ b/scripty-client.el
@@ -36,10 +36,12 @@ available on your path")
 (defun scripty/prompt-for-command! ()
   (let ((choices (scripty/get-choices!)))
     (unless (null choices)
+      (if (-contains? choices scripty/last-script)
+          (setq choices (-uniq (cons scripty/last-script choices))))
       (let ((completion
              (ido-completing-read
-              (concat "command (default: \"" scripty/last-script "\"): ") choices nil t)))
-        (if (s-blank? completion) scripty/last-script completion)))))
+              (concat "command: ") choices nil t)))
+        completion))))
 
 (defun scripty/get-buffer-name! (command)
   "given the name of a command, build a suggested buffer name.


### PR DESCRIPTION
Defaults don't really work so well for ido completions because there's
no way to provide an empty string if you have a list of values, unless
the empty string is one of those values. The way smex handles this is to
just put the default choice at the beginning of the list, giving you a
simple UI and minimal keystrokes. We've followed that here.